### PR TITLE
Fix email Validation

### DIFF
--- a/bookclub/templates/activate.html
+++ b/bookclub/templates/activate.html
@@ -9,8 +9,8 @@ To begin finding and interacting with users like you, please click the link belo
 http://{{domain}}{% url 'activate' user_id token %}
 
 If you believe this email was sent to you in error, please ignore this email. Any replies to this email will be ignored.
-<img src=""
 Sincerely,
 The Bookwise Team
+
 
 {% endautoescape %}

--- a/system/settings.py
+++ b/system/settings.py
@@ -163,7 +163,7 @@ EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_HOST_USER = 'bookwise0000@gmail.com'
-EMAIL_HOST_PASSWORD = 'Bookwise123!'
+EMAIL_HOST_PASSWORD = 'xadxrneeznkqtewt'
 DEFAULT_FROM_EMAIL = 'bookwise0000@gmail.com'
 SERVER_EMAIL = 'bookwise0000@gmail.com'
 


### PR DESCRIPTION
Use Google's App Password to allow sending emails from backend.